### PR TITLE
(Feature) add Goerli testnet

### DIFF
--- a/helpers/enum.js
+++ b/helpers/enum.js
@@ -1,0 +1,16 @@
+const networkIDs = {
+	MAINNET_CODE: 1,
+	ROPSTEN_CODE: 3,
+	RINKEBY_CODE: 4,
+	GOERLI_CODE: 5,
+	KOVAN_CODE: 42,
+	SOKOL_CODE: 77,
+	POA_CORE_CODE: 99,
+	XDAI_CODE: 100,
+	RSK_CODE: 30,
+	RSK_TESTNET_CODE: 31,
+}
+
+module.exports = {
+	networkIDs
+}

--- a/helpers/get-explorer-links.js
+++ b/helpers/get-explorer-links.js
@@ -9,7 +9,6 @@ const {
 	POA_CORE_CODE,
 	XDAI_CODE,
 	RSK_CODE,
-	RSK_TESTNET_CODE,
 } = networkIDs
 
 const POA_IDs = [SOKOL_CODE, POA_CORE_CODE, XDAI_CODE]

--- a/helpers/get-explorer-links.js
+++ b/helpers/get-explorer-links.js
@@ -1,36 +1,61 @@
-const POAIDs = [77, 99, 100]
-const RSKIDs = [30]
+const { networkIDs } = require('./enum')
+const {
+	MAINNET_CODE,
+	ROPSTEN_CODE,
+	RINKEBY_CODE,
+	GOERLI_CODE,
+	KOVAN_CODE,
+	SOKOL_CODE,
+	POA_CORE_CODE,
+	XDAI_CODE,
+	RSK_CODE,
+	RSK_TESTNET_CODE,
+} = networkIDs
+
+const POA_IDs = [SOKOL_CODE, POA_CORE_CODE, XDAI_CODE]
+const RSK_IDs = [RSK_CODE]
+const ETH_IDs = [GOERLI_CODE]
+
+const blockScoutLink = (net, prefix) => `https://blockscout.com/${net}/${prefix}`
+const etherscanLink = (prefix) => `https://${prefix}etherscan.io`
+const rskExplorerLink = 'https://explorer.rsk.co'
 
 const getExplorerAccountLinkFor = (account, network) => {
 	const prefix = getExplorerPrefix(network)
-	if (POAIDs.includes(parseInt(network))) {
-		return `https://blockscout.com/poa/${prefix}/address/${account}`
-	} else if (RSKIDs.includes(parseInt(network))) {
-		return `https://explorer.rsk.co/address/${account}`
+	if (POA_IDs.includes(parseInt(network))) {
+		return `${blockScoutLink('poa', prefix)}/address/${account}`
+	} else if (ETH_IDs.includes(parseInt(network))) {
+		return `${blockScoutLink('eth', prefix)}/address/${account}`
+	} else if (RSK_IDs.includes(parseInt(network))) {
+		return `${rskExplorerLink}/address/${account}`
 	} else {
-		return `https://${prefix}etherscan.io/address/${account}`
+		return `${etherscanLink(prefix)}/address/${account}`
 	}
 }
 
 const getExplorerTxLinkFor = (hash, network) => {
 	const prefix = getExplorerPrefix(network)
-	if (POAIDs.includes(parseInt(network))) {
-		return `https://blockscout.com/poa/${prefix}/tx/${hash}`
-	} else if (RSKIDs.includes(parseInt(network))) {
-		return `https://explorer.rsk.co/tx/${hash}`
+	if (POA_IDs.includes(parseInt(network))) {
+		return `${blockScoutLink('poa', prefix)}/tx/${hash}`
+	} else if (ETH_IDs.includes(parseInt(network))) {
+		return `${blockScoutLink('eth', prefix)}/tx/${hash}`
+	} else if (RSK_IDs.includes(parseInt(network))) {
+		return `${rskExplorerLink}/tx/${hash}`
 	} else {
-		return `https://${prefix}etherscan.io/tx/${hash}`
+		return `${etherscanLink(prefix)}/tx/${hash}`
 	}
 }
 
 const getExplorerTokenLinkFor = (tokenAddress, account, network) => {
 	const prefix = getExplorerPrefix(network)
-	if (POAIDs.includes(parseInt(network))) {
-		return `https://blockscout.com/poa/${prefix}/address/${tokenAddress}`
-	} else if (RSKIDs.includes(parseInt(network))) {
-		return `https://explorer.rsk.co/token/${tokenAddress}/account/${account}`
+	if (POA_IDs.includes(parseInt(network))) {
+		return `${blockScoutLink('poa', prefix)}/address/${tokenAddress}`
+	} else if (ETH_IDs.includes(parseInt(network))) {
+		return `${blockScoutLink('eth', prefix)}/address/${tokenAddress}`
+	} else if (RSK_IDs.includes(parseInt(network))) {
+		return `${rskExplorerLink}/token/${tokenAddress}/account/${account}`
 	} else {
-		return `https://${prefix}etherscan.io/token/${tokenAddress}?a=${account}`
+		return `${etherscanLink(prefix)}/token/${tokenAddress}?a=${account}`
 	}
 }
 
@@ -38,26 +63,29 @@ function getExplorerPrefix (network) {
 	const net = parseInt(network)
 	let prefix
 	switch (net) {
-	case 1: // main net
+	case MAINNET_CODE: // main net
 		prefix = ''
 		break
-	case 3: // ropsten test net
+	case ROPSTEN_CODE: // ropsten test net
 		prefix = 'ropsten.'
 		break
-	case 4: // rinkeby test net
+	case RINKEBY_CODE: // rinkeby test net
 		prefix = 'rinkeby.'
 		break
-	case 42: // kovan test net
+	case KOVAN_CODE: // kovan test net
 		prefix = 'kovan.'
 		break
-	case 77: // POA Sokol test net
+	case SOKOL_CODE: // POA Sokol test net
 		prefix = 'sokol'
 		break
-	case 99: // POA Core net
+	case POA_CORE_CODE: // POA Core net
 		prefix = 'core'
 		break
-	case 100: // Dai chain
+	case XDAI_CODE: // Dai chain
 		prefix = 'dai'
+		break
+	case GOERLI_CODE: // Goerli testnet
+		prefix = 'goerli'
 		break
 	default:
 		prefix = ''

--- a/helpers/get-faucet-links.js
+++ b/helpers/get-faucet-links.js
@@ -1,15 +1,27 @@
+const { networkIDs } = require('./enum')
+const {
+	ROPSTEN_CODE,
+	RINKEBY_CODE,
+	GOERLI_CODE,
+	KOVAN_CODE,
+	SOKOL_CODE,
+	RSK_TESTNET_CODE,
+} = networkIDs
+
 function getFaucetLinks(network) {
 	const netID = parseInt(network)
 	switch (netID) {
-	case 3:
+	case ROPSTEN_CODE:
 		return ['https://faucet.metamask.io/']
-	case 4:
+	case RINKEBY_CODE:
 		return ['https://faucet.rinkeby.io/']
-	case 42:
+	case GOERLI_CODE:
+		return ['https://goerli-faucet.slock.it/']
+	case KOVAN_CODE:
 		return ['https://faucet.kovan.network/', 'https://gitter.im/kovan-testnet/faucet/']
-	case 77:
+	case SOKOL_CODE:
 		return ['https://faucet.poa.network/']
-	case 31:
+	case RSK_TESTNET_CODE:
 		return ['https://faucet.testnet.rsk.co/']
 	default:
 		return []

--- a/helpers/get-net-properties.js
+++ b/helpers/get-net-properties.js
@@ -1,23 +1,39 @@
+const { networkIDs } = require('./enum')
+const {
+	MAINNET_CODE,
+	ROPSTEN_CODE,
+	RINKEBY_CODE,
+	GOERLI_CODE,
+	KOVAN_CODE,
+	SOKOL_CODE,
+	POA_CORE_CODE,
+	XDAI_CODE,
+	RSK_CODE,
+	RSK_TESTNET_CODE,
+} = networkIDs
+
 function getNetworkDisplayName(network) {
 	const netID = parseInt(network)
 	switch (netID) {
-	case 1:
+	case MAINNET_CODE:
 		return 'Main Ethereum Network'
-	case 3:
+	case ROPSTEN_CODE:
 		return 'Ropsten Test Network'
-	case 4:
+	case RINKEBY_CODE:
 		return 'Rinkeby Test Network'
-	case 42:
+	case GOERLI_CODE:
+		return 'Goerli Test Network'
+	case KOVAN_CODE:
 		return 'Kovan Test Network'
-	case 77:
+	case SOKOL_CODE:
 		return 'POA Sokol Test Network'
-	case 99:
+	case POA_CORE_CODE:
 		return 'POA Network'
-	case 100:
+	case XDAI_CODE:
 		return 'xDai Chain'
-	case 30:
+	case RSK_CODE:
 		return 'RSK Mainnet'
-	case 31:
+	case RSK_TESTNET_CODE:
 		return 'RSK Testnet'
 	default:
 		return 'Unknown Private Network'
@@ -27,14 +43,16 @@ function getNetworkDisplayName(network) {
 function getNetworkCoinName(network) {
 	const netID = parseInt(network)
 	switch (netID) {
-	case 77:
-	case 99:
+	case SOKOL_CODE:
+	case POA_CORE_CODE:
 		return 'POA'
-	case 30:
-	case 31:
+	case RSK_CODE:
+	case RSK_TESTNET_CODE:
 		return 'RBTC'
-	case 100:
+	case XDAI_CODE:
 		return 'xDAI'
+	case GOERLI_CODE:
+		return 'GöETH'
 	default:
 		return 'ETH'
 	}
@@ -43,10 +61,10 @@ function getNetworkCoinName(network) {
 function isTestnet(network) {
 	const netID = parseInt(network)
 	switch (netID) {
-	case 1:
-	case 99:
-	case 100:
-	case 30:
+	case MAINNET_CODE:
+	case POA_CORE_CODE:
+	case XDAI_CODE:
+	case RSK_CODE:
 		return false
 	default:
 		return true

--- a/helpers/get-rpc-endpoints.js
+++ b/helpers/get-rpc-endpoints.js
@@ -1,23 +1,39 @@
+const { networkIDs } = require('./enum')
+const {
+	MAINNET_CODE,
+	ROPSTEN_CODE,
+	RINKEBY_CODE,
+	GOERLI_CODE,
+	KOVAN_CODE,
+	SOKOL_CODE,
+	POA_CORE_CODE,
+	XDAI_CODE,
+	RSK_CODE,
+	RSK_TESTNET_CODE,
+} = networkIDs
+
 function getRPCEndpoints(network) {
 	const netID = parseInt(network)
 	switch (netID) {
-	case 1:
+	case MAINNET_CODE:
 		return ['https://mainnet.infura.io/']
-	case 3:
+	case ROPSTEN_CODE:
 		return ['https://ropsten.infura.io/']
-	case 4:
+	case RINKEBY_CODE:
 		return ['https://rinkeby.infura.io/']
-	case 42:
+	case GOERLI_CODE:
+		return ['https://goerli.blockscout.com/']
+	case KOVAN_CODE:
 		return ['https://kovan.infura.io/']
-	case 77:
+	case SOKOL_CODE:
 		return ['https://sokol.poa.network/']
-	case 99:
+	case POA_CORE_CODE:
 		return ['https://core.poa.network/']
-	case 100:
+	case XDAI_CODE:
 		return ['https://dai.poa.network/']
-	case 30:
+	case RSK_CODE:
 		return ['https://public-node.rsk.co']
-	case 31:
+	case RSK_TESTNET_CODE:
 		return ['https://public-node.testnet.rsk.co']
 	default:
 		return []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-net-props",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-net-props",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Get properties of EMV-based network",
   "main": "index.js",
   "directories": {

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,9 @@ describe('eth-net-props', () => {
 			it(`${claimPrefix} RSK Mainnet`, () => {
 				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 30), 'https://explorer.rsk.co/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
 			})
+			it(`${claimPrefix} Goerli Testnet`, () => {
+				assert.equal(explorerLinks.getExplorerAccountLinkFor('0xd8fe15886d2dcbc5d7c06394beb417aadaf1eee0', 5), 'https://blockscout.com/eth/goerli/address/0xd8fe15886d2dcbc5d7c06394beb417aadaf1eee0')
+			})
 		})
 
 		describe ('getExplorerTxLinkFor()', () => {
@@ -62,6 +65,9 @@ describe('eth-net-props', () => {
 			it(`${claimPrefix} RSK Mainnet`, () => {
 				assert.equal(explorerLinks.getExplorerTxLinkFor('0x33a7511c7838f5be0ade40d732f0a51cd28c8a641de9079836170cbdac8e7d83', 30), 'https://explorer.rsk.co/tx/0x33a7511c7838f5be0ade40d732f0a51cd28c8a641de9079836170cbdac8e7d83')
 			})
+			it(`${claimPrefix} Goerli Testnet`, () => {
+				assert.equal(explorerLinks.getExplorerTxLinkFor('0xb9599801c83e6aa20769e7dcdce0989c7380ba78cb587d3d7db11e1b30b17b54', 5), 'https://blockscout.com/eth/goerli/tx/0xb9599801c83e6aa20769e7dcdce0989c7380ba78cb587d3d7db11e1b30b17b54')
+			})
 		})
 
 		describe ('getExplorerTokenLinkFor()', () => {
@@ -88,6 +94,9 @@ describe('eth-net-props', () => {
 			})
 			it(`${claimPrefix} RSK Mainnet`, () => {
 				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x16cb2604ce5951c8506fbf690d816be6d0aa00fb', '0x604056c0f88aed17ef975269aab1ae9d02840bb2', 30), 'https://explorer.rsk.co/token/0x16cb2604ce5951c8506fbf690d816be6d0aa00fb/account/0x604056c0f88aed17ef975269aab1ae9d02840bb2')
+			})
+			it(`${claimPrefix} Goerli testnet`, () => {
+				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xd8fe15886d2dcbc5d7c06394beb417aadaf1eee0', '0x604056c0f88aed17ef975269aab1ae9d02840bb2', 5), 'https://blockscout.com/eth/goerli/address/0xd8fe15886d2dcbc5d7c06394beb417aadaf1eee0')
 			})
 		})
 	})
@@ -128,6 +137,13 @@ describe('eth-net-props', () => {
 			assert.equal(RSKFaucetLinks.length, 1)
 			if (RSKFaucetLinks.length > 0) {
 				assert.equal(RSKFaucetLinks[0], 'https://faucet.testnet.rsk.co/')
+			}
+		})
+		it(`${claimPrefix} Goerli Network`, () => {
+			const goerliFaucetLinks = faucetLinks.getFaucetLinks(5)
+			assert.equal(goerliFaucetLinks.length, 1)
+			if (goerliFaucetLinks.length > 0) {
+				assert.equal(goerliFaucetLinks[0], 'https://goerli-faucet.slock.it/')
 			}
 		})
 		it('should not return faucet link for production blockchains', () => {
@@ -203,6 +219,13 @@ describe('eth-net-props', () => {
 				assert.equal(RSKRPCEndpoints[0], 'https://public-node.testnet.rsk.co')
 			}
 		})
+		it(`${claimPrefix} Goerli testnet`, () => {
+			const GoerliRPCEndpoints = RPCEndpoints.getRPCEndpoints(5)
+			assert.equal(GoerliRPCEndpoints.length, 1)
+			if (GoerliRPCEndpoints.length > 0) {
+				assert.equal(GoerliRPCEndpoints[0], 'https://goerli.blockscout.com/')
+			}
+		})
 	})
 
 	claimPrefix = 'should return correct display name for'
@@ -234,6 +257,9 @@ describe('eth-net-props', () => {
 		it(`${claimPrefix} RSK Testnet`, () => {
 			assert.equal(netProps.getNetworkDisplayName(31), 'RSK Testnet')
 		})
+		it(`${claimPrefix} Goerli Testnet`, () => {
+			assert.equal(netProps.getNetworkDisplayName(5), 'Goerli Test Network')
+		})
 
 		claimPrefix = 'should return correct coin name for'
 		it(`${claimPrefix} Sokol POA Network`, () => {
@@ -263,6 +289,9 @@ describe('eth-net-props', () => {
 		it(`${claimPrefix} RSK Testnet`, () => {
 			assert.equal(netProps.getNetworkCoinName(31), 'RBTC')
 		})
+		it(`${claimPrefix} Goerli Testnet`, () => {
+			assert.equal(netProps.getNetworkCoinName(5), 'GöETH')
+		})
 
 		it('Sokol POA Network is a testnet', () => {
 			assert.equal(netProps.isTestnet(77), true)
@@ -290,6 +319,9 @@ describe('eth-net-props', () => {
 		})
 		it('RSK Testnet is a testnet', () => {
 			assert.equal(netProps.isTestnet(31), true)
+		})
+		it('Goerli Testnet is a testnet', () => {
+			assert.equal(netProps.isTestnet(5), true)
 		})
 	})
 })


### PR DESCRIPTION
RPC: https://goerli.blockscout.com/
Faucet: https://goerli-faucet.slock.it/
Explorer: https://blockscout.com/eth/goerli

+ refactoring: enums for network IDs