### PR TITLE
(Fix) Shrink the name for Sokol - remove POA

### DIFF
--- a/helpers/get-net-properties.js
+++ b/helpers/get-net-properties.js
@@ -26,7 +26,7 @@ function getNetworkDisplayName(network) {
 	case KOVAN_CODE:
 		return 'Kovan Test Network'
 	case SOKOL_CODE:
-		return 'POA Sokol Test Network'
+		return 'Sokol Test Network'
 	case POA_CORE_CODE:
 		return 'POA Network'
 	case XDAI_CODE:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-net-props",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-net-props",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Get properties of EMV-based network",
   "main": "index.js",
   "directories": {

--- a/test/test.js
+++ b/test/test.js
@@ -231,7 +231,7 @@ describe('eth-net-props', () => {
 	claimPrefix = 'should return correct display name for'
 	describe('get network properties', () => {
 		it(`${claimPrefix} Sokol POA Network`, () => {
-			assert.equal(netProps.getNetworkDisplayName(77), 'POA Sokol Test Network')
+			assert.equal(netProps.getNetworkDisplayName(77), 'Sokol Test Network')
 		})
 		it(`${claimPrefix} Core POA Network`, () => {
 			assert.equal(netProps.getNetworkDisplayName(99), 'POA Network')


### PR DESCRIPTION
Replace `POA Sokol Test Network` with `Sokol Test Network`