### PR TITLE
new RPC endpoint for Ethereum Classic

### DIFF
--- a/helpers/get-rpc-endpoints.js
+++ b/helpers/get-rpc-endpoints.js
@@ -37,7 +37,7 @@ function getRPCEndpoints(network) {
 	case RSK_TESTNET_CODE:
 		return ['https://public-node.testnet.rsk.co']
 	case CLASSIC_CODE:
-		return ['https://etc-parity.0xinfra.com']
+		return ['https://classic.blockscout.com']
 	default:
 		return []
 	}


### PR DESCRIPTION
During testing of the TokenBridge UI app it was found that the node used by NiftyWallet to connect to Ethereum Classic does not support `eth_chainId` JSON RPC calls.

It is suggested to use another node of Ethereum Classic - `https://classic.blockscout.com`. It is maintained by POA team.