### PR TITLE
Blockscout links for all chains

### DIFF
--- a/helpers/get-explorer-links.js
+++ b/helpers/get-explorer-links.js
@@ -12,57 +12,52 @@ const {
 	CLASSIC_CODE,
 } = networkIDs
 
-const POA_IDs = [SOKOL_CODE, POA_CORE_CODE, XDAI_CODE]
-const RSK_IDs = [RSK_CODE]
-const ETH_IDs = [GOERLI_CODE]
-
 const blockScoutLink = (net, prefix) => `https://blockscout.com/${net}/${prefix}`
-const etherscanLink = (prefix) => `https://${prefix}etherscan.io`
-const rskExplorerLink = 'https://explorer.rsk.co'
 
 const getExplorerAccountLinkFor = (account, network) => {
 	const prefix = getExplorerPrefix(network)
-	if (POA_IDs.includes(parseInt(network))) {
-		return `${blockScoutLink('poa', prefix)}/address/${account}`
-	} else if (parseInt(network) === CLASSIC_CODE) {
-		return `${blockScoutLink('etc', prefix)}/address/${account}`
-	} else if (ETH_IDs.includes(parseInt(network))) {
-		return `${blockScoutLink('eth', prefix)}/address/${account}`
-	} else if (RSK_IDs.includes(parseInt(network))) {
-		return `${rskExplorerLink}/address/${account}`
-	} else {
-		return `${etherscanLink(prefix)}/address/${account}`
-	}
+	const chain = getExplorerChain(network)
+	return `${blockScoutLink(chain, prefix)}/address/${account}`
 }
 
 const getExplorerTxLinkFor = (hash, network) => {
 	const prefix = getExplorerPrefix(network)
-	if (POA_IDs.includes(parseInt(network))) {
-		return `${blockScoutLink('poa', prefix)}/tx/${hash}`
-	} else if (parseInt(network) === CLASSIC_CODE) {
-		return `${blockScoutLink('etc', prefix)}/tx/${hash}`
-	} else if (ETH_IDs.includes(parseInt(network))) {
-		return `${blockScoutLink('eth', prefix)}/tx/${hash}`
-	} else if (RSK_IDs.includes(parseInt(network))) {
-		return `${rskExplorerLink}/tx/${hash}`
-	} else {
-		return `${etherscanLink(prefix)}/tx/${hash}`
-	}
+	const chain = getExplorerChain(network)
+	return `${blockScoutLink(chain, prefix)}/tx/${hash}`
 }
 
 const getExplorerTokenLinkFor = (tokenAddress, account, network) => {
 	const prefix = getExplorerPrefix(network)
-	if (POA_IDs.includes(parseInt(network))) {
-		return `${blockScoutLink('poa', prefix)}/tokens/${tokenAddress}`
-	} else if (parseInt(network) === CLASSIC_CODE) {
-		return `${blockScoutLink('etc', prefix)}/tokens/${tokenAddress}`
-	} else if (ETH_IDs.includes(parseInt(network))) {
-		return `${blockScoutLink('eth', prefix)}/tokens/${tokenAddress}`
-	} else if (RSK_IDs.includes(parseInt(network))) {
-		return `${rskExplorerLink}/token/${tokenAddress}/account/${account}`
-	} else {
-		return `${etherscanLink(prefix)}/token/${tokenAddress}?a=${account}`
+	const chain = getExplorerChain(network)
+	return `${blockScoutLink(chain, prefix)}/tokens/${tokenAddress}`
+}
+
+function getExplorerChain (network) {
+	const net = parseInt(network)
+	let chain
+	switch (net) {
+	case MAINNET_CODE: // main net
+	case ROPSTEN_CODE: // ropsten testnet
+	case RINKEBY_CODE: // rinkeby testnet
+	case KOVAN_CODE: // kovan testnet
+	case GOERLI_CODE: // Goerli testnet
+		chain = 'eth'
+		break
+	case SOKOL_CODE: // POA Sokol testnet
+	case POA_CORE_CODE: // POA Core
+	case XDAI_CODE: // xDai chain
+		chain = 'poa'
+		break
+	case CLASSIC_CODE: // ETC
+		chain = 'etc'
+		break
+	case RSK_CODE: // RSK mainnet
+		chain = 'rsk'
+		break
+	default:
+		chain = ''
 	}
+	return chain
 }
 
 function getExplorerPrefix (network) {
@@ -70,31 +65,30 @@ function getExplorerPrefix (network) {
 	let prefix
 	switch (net) {
 	case MAINNET_CODE: // main net
-		prefix = ''
+	case CLASSIC_CODE: // ETC
+	case RSK_CODE: // RSK mainnet
+		prefix = 'mainnet'
 		break
-	case ROPSTEN_CODE: // ropsten test net
-		prefix = 'ropsten.'
+	case ROPSTEN_CODE: // ropsten testnet
+		prefix = 'ropsten'
 		break
-	case RINKEBY_CODE: // rinkeby test net
-		prefix = 'rinkeby.'
+	case RINKEBY_CODE: // rinkeby testnet
+		prefix = 'rinkeby'
 		break
-	case KOVAN_CODE: // kovan test net
-		prefix = 'kovan.'
+	case KOVAN_CODE: // kovan testnet
+		prefix = 'kovan'
 		break
-	case SOKOL_CODE: // POA Sokol test net
+	case SOKOL_CODE: // POA Sokol testnet
 		prefix = 'sokol'
 		break
-	case POA_CORE_CODE: // POA Core net
+	case POA_CORE_CODE: // POA Core
 		prefix = 'core'
 		break
-	case XDAI_CODE: // Dai chain
+	case XDAI_CODE: // xDai chain
 		prefix = 'dai'
 		break
 	case GOERLI_CODE: // Goerli testnet
 		prefix = 'goerli'
-		break
-	case CLASSIC_CODE: // Goerli testnet
-		prefix = 'mainnet'
 		break
 	default:
 		prefix = ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-net-props",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-net-props",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Get properties of EMV-based network",
   "main": "index.js",
   "directories": {

--- a/test/test.js
+++ b/test/test.js
@@ -21,19 +21,19 @@ describe('eth-net-props', () => {
 				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x15c40c6de9f2299680a4522d8635c9b394eded09', 100), 'https://blockscout.com/poa/dai/address/0x15c40c6de9f2299680a4522d8635c9b394eded09')
 			})
 			it(`${claimPrefix} Mainnet`, () => {
-				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 1), 'https://etherscan.io/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 1), 'https://blockscout.com/eth/mainnet/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
 			})
 			it(`${claimPrefix} Ropsten`, () => {
-				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 3), 'https://ropsten.etherscan.io/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 3), 'https://blockscout.com/eth/ropsten/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
 			})
 			it(`${claimPrefix} Rinkeby`, () => {
-				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 4), 'https://rinkeby.etherscan.io/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 4), 'https://blockscout.com/eth/rinkeby/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
 			})
 			it(`${claimPrefix} Kovan`, () => {
-				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 42), 'https://kovan.etherscan.io/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 42), 'https://blockscout.com/eth/kovan/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
 			})
 			it(`${claimPrefix} RSK Mainnet`, () => {
-				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 30), 'https://explorer.rsk.co/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerAccountLinkFor('0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 30), 'https://blockscout.com/rsk/mainnet/address/0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
 			})
 			it(`${claimPrefix} Goerli Testnet`, () => {
 				assert.equal(explorerLinks.getExplorerAccountLinkFor('0xd8fe15886d2dcbc5d7c06394beb417aadaf1eee0', 5), 'https://blockscout.com/eth/goerli/address/0xd8fe15886d2dcbc5d7c06394beb417aadaf1eee0')
@@ -57,19 +57,19 @@ describe('eth-net-props', () => {
 				assert.equal(explorerLinks.getExplorerTxLinkFor('0xb3b01bcc1a73477cd86de989cc207fa59f87ea601dea298772f4b1b3f6f1407e', 100), 'https://blockscout.com/poa/dai/tx/0xb3b01bcc1a73477cd86de989cc207fa59f87ea601dea298772f4b1b3f6f1407e')
 			})
 			it(`${claimPrefix} Mainnet`, () => {
-				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 1), 'https://etherscan.io/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
+				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 1), 'https://blockscout.com/eth/mainnet/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
 			})
 			it(`${claimPrefix} Ropsten`, () => {
-				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 3), 'https://ropsten.etherscan.io/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
+				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 3), 'https://blockscout.com/eth/ropsten/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
 			})
 			it(`${claimPrefix} Rinkeby`, () => {
-				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 4), 'https://rinkeby.etherscan.io/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
+				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 4), 'https://blockscout.com/eth/rinkeby/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
 			})
 			it(`${claimPrefix} Kovan`, () => {
-				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 42), 'https://kovan.etherscan.io/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
+				assert.equal(explorerLinks.getExplorerTxLinkFor('0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305', 42), 'https://blockscout.com/eth/kovan/tx/0x892c825d1ec25b0a1a27aa5dff5b54fc4488a45029d0087fc40d3d733ded7305')
 			})
 			it(`${claimPrefix} RSK Mainnet`, () => {
-				assert.equal(explorerLinks.getExplorerTxLinkFor('0x33a7511c7838f5be0ade40d732f0a51cd28c8a641de9079836170cbdac8e7d83', 30), 'https://explorer.rsk.co/tx/0x33a7511c7838f5be0ade40d732f0a51cd28c8a641de9079836170cbdac8e7d83')
+				assert.equal(explorerLinks.getExplorerTxLinkFor('0x33a7511c7838f5be0ade40d732f0a51cd28c8a641de9079836170cbdac8e7d83', 30), 'https://blockscout.com/rsk/mainnet/tx/0x33a7511c7838f5be0ade40d732f0a51cd28c8a641de9079836170cbdac8e7d83')
 			})
 			it(`${claimPrefix} Goerli Testnet`, () => {
 				assert.equal(explorerLinks.getExplorerTxLinkFor('0xb9599801c83e6aa20769e7dcdce0989c7380ba78cb587d3d7db11e1b30b17b54', 5), 'https://blockscout.com/eth/goerli/tx/0xb9599801c83e6aa20769e7dcdce0989c7380ba78cb587d3d7db11e1b30b17b54')
@@ -90,19 +90,19 @@ describe('eth-net-props', () => {
 				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xabe71e6a260c2eea3c30864dc50639100aa315f6', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 100), 'https://blockscout.com/poa/dai/tokens/0xabe71e6a260c2eea3c30864dc50639100aa315f6')
 			})
 			it(`${claimPrefix} Mainnet`, () => {
-				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 1), 'https://etherscan.io/token/0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE?a=0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x5a386eb0fcbfee3f0d759e263053c09162ff102d', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 1), 'https://blockscout.com/eth/mainnet/tokens/0x5a386eb0fcbfee3f0d759e263053c09162ff102d')
 			})
 			it(`${claimPrefix} Ropsten`, () => {
-				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 3), 'https://ropsten.etherscan.io/token/0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE?a=0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 3), 'https://blockscout.com/eth/ropsten/tokens/0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE')
 			})
 			it(`${claimPrefix} Rinkeby`, () => {
-				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 4), 'https://rinkeby.etherscan.io/token/0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE?a=0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x4cc97adba4298d575ad22a42a976af4e2250b328', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 4), 'https://blockscout.com/eth/rinkeby/tokens/0x4cc97adba4298d575ad22a42a976af4e2250b328')
 			})
 			it(`${claimPrefix} Kovan`, () => {
-				assert.equal(explorerLinks.getExplorerTokenLinkFor('0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 42), 'https://kovan.etherscan.io/token/0xcf2AEDCfb4ff2c9020fb61c41226A4DfD77D12dE?a=0x70FDd102DDB03Dc55B1719E76DfeA784916621fd')
+				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x50c9fd8e20792e2decc5e35a0c1d17a51555347b', '0x70FDd102DDB03Dc55B1719E76DfeA784916621fd', 42), 'https://blockscout.com/eth/kovan/tokens/0x50c9fd8e20792e2decc5e35a0c1d17a51555347b')
 			})
 			it(`${claimPrefix} RSK Mainnet`, () => {
-				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x16cb2604ce5951c8506fbf690d816be6d0aa00fb', '0x604056c0f88aed17ef975269aab1ae9d02840bb2', 30), 'https://explorer.rsk.co/token/0x16cb2604ce5951c8506fbf690d816be6d0aa00fb/account/0x604056c0f88aed17ef975269aab1ae9d02840bb2')
+				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x16cb2604ce5951c8506fbf690d816be6d0aa00fb', '0x604056c0f88aed17ef975269aab1ae9d02840bb2', 30), 'https://blockscout.com/rsk/mainnet/tokens/0x16cb2604ce5951c8506fbf690d816be6d0aa00fb')
 			})
 			it(`${claimPrefix} Goerli testnet`, () => {
 				assert.equal(explorerLinks.getExplorerTokenLinkFor('0x7af963cf6d228e564e2a0aa0ddbf06210b38615d', '0x604056c0f88aed17ef975269aab1ae9d02840bb2', 5), 'https://blockscout.com/eth/goerli/tokens/0x7af963cf6d228e564e2a0aa0ddbf06210b38615d')


### PR DESCRIPTION
Blockscout Ethereum explorer supports all of the chains.
Explorer links are changed to Blockscout.